### PR TITLE
Add Claude Code reviewer (tmux, webhooks, blocks merges)

### DIFF
--- a/cli/tagbag
+++ b/cli/tagbag
@@ -131,6 +131,7 @@ Commands:
   logs [service...]       Tail service logs
 
   push <owner/repo> [opts] Push a Gitea repo to GitHub (code+commits+tags)
+  reviewer                Manage Claude Code reviewer (tmux, webhooks)
   plane                   Plane issue tracker commands
   gitea                   Gitea git/PR commands (wraps tea CLI)
   ci                      Woodpecker CI commands (wraps woodpecker-cli)
@@ -693,6 +694,106 @@ cmd_logs() {
     docker compose -f "${compose_dir}/docker-compose.yml" logs -f "$@"
 }
 
+# ─── Reviewer Command ────────────────────────────────────────────────────────
+
+TMUX_SESSION="tagbag-reviewer"
+
+reviewer_help() {
+    cat <<'EOF'
+tagbag reviewer — manage the Claude Code reviewer tmux session
+
+Usage: tagbag reviewer <subcommand>
+
+Subcommands:
+  start                   Start the reviewer (tmux + webhook server)
+  stop                    Stop the reviewer
+  status                  Show reviewer status
+  logs                    Tail reviewer logs
+  register <owner/repo>   Register a Gitea repo webhook for review
+
+The reviewer listens for Gitea push webhooks, clones the repo,
+runs Claude Code for a thorough review, posts a comment, and
+sets commit status (pass/fail) to block or allow merges.
+EOF
+}
+
+cmd_reviewer() {
+    local subcmd="${1:-help}"
+    shift 2>/dev/null || true
+
+    case "$subcmd" in
+        help|--help|-h) reviewer_help ;;
+
+        start)
+            if tmux has-session -t "$TMUX_SESSION" 2>/dev/null; then
+                warn "Reviewer already running (tmux session: ${TMUX_SESSION})"
+                tmux list-sessions -F "#{session_name} #{session_created_string}" 2>/dev/null | grep "$TMUX_SESSION"
+                return
+            fi
+            local reviewer_dir
+            reviewer_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/../reviewer" && pwd)"
+            mkdir -p "${TAGBAG_CLONE_DIR}"
+            info "Starting reviewer in tmux session '${TMUX_SESSION}'..."
+            tmux new-session -d -s "$TMUX_SESSION" "bash ${reviewer_dir}/webhook-server.sh"
+            echo -e "${GREEN}Reviewer started.${NC}"
+            echo "  tmux session: ${TMUX_SESSION}"
+            echo "  Webhook port: ${TAGBAG_REVIEW_PORT:-9876}"
+            echo "  Clone dir:    ${TAGBAG_CLONE_DIR}"
+            echo "  Attach:       tmux attach -t ${TMUX_SESSION}"
+            echo "  Logs:         tagbag reviewer logs"
+            ;;
+
+        stop)
+            if tmux has-session -t "$TMUX_SESSION" 2>/dev/null; then
+                tmux kill-session -t "$TMUX_SESSION"
+                echo -e "${GREEN}Reviewer stopped.${NC}"
+            else
+                warn "Reviewer is not running."
+            fi
+            ;;
+
+        status)
+            if tmux has-session -t "$TMUX_SESSION" 2>/dev/null; then
+                echo -e "${GREEN}Reviewer is running${NC}"
+                echo "  tmux session: ${TMUX_SESSION}"
+                echo "  Webhook port: ${TAGBAG_REVIEW_PORT:-9876}"
+                echo "  Clone dir:    ${TAGBAG_CLONE_DIR}"
+                local queue
+                queue="${XDG_CONFIG_HOME:-$HOME/.config}/tagbag/review-queue"
+                if [[ -f "$queue" ]]; then
+                    local qlen
+                    qlen=$(wc -l < "$queue" | tr -d ' ')
+                    echo "  Queue depth:  ${qlen}"
+                fi
+            else
+                echo -e "${YELLOW}Reviewer is not running${NC}"
+                echo "  Start with: tagbag reviewer start"
+            fi
+            ;;
+
+        logs)
+            local logfile
+            logfile="${XDG_CONFIG_HOME:-$HOME/.config}/tagbag/reviewer.log"
+            if [[ -f "$logfile" ]]; then
+                tail -f "$logfile"
+            else
+                warn "No reviewer log found at ${logfile}"
+            fi
+            ;;
+
+        register)
+            local repo="${1:?Usage: tagbag reviewer register <owner/repo>}"
+            require_gitea_token
+            local webhook_url="http://host.docker.internal:${TAGBAG_REVIEW_PORT:-9876}"
+            info "Registering webhook for ${repo} → ${webhook_url}"
+            gitea_api POST "/repos/${repo}/hooks" \
+                -d "$(jq -n --arg url "$webhook_url" \
+                    '{type:"gitea",active:true,config:{url:$url,content_type:"json"},events:["push"]}')" | jq '{id, url: .config.url, events, active}' ;;
+
+        *) die "Unknown reviewer subcommand: $subcmd. Run 'tagbag reviewer --help'." ;;
+    esac
+}
+
 # ─── Push Command ────────────────────────────────────────────────────────────
 
 push_help() {
@@ -959,6 +1060,7 @@ main() {
         build)          cmd_build "$@" ;;
         logs)           cmd_logs "$@" ;;
         push)           cmd_push "$@" ;;
+        reviewer)       cmd_reviewer "$@" ;;
         plane)          cmd_plane "$@" ;;
         gitea)          cmd_gitea "$@" ;;
         ci)             cmd_ci "$@" ;;

--- a/reviewer/do-review.sh
+++ b/reviewer/do-review.sh
@@ -1,0 +1,149 @@
+#!/usr/bin/env bash
+# Perform a code review for a single push event.
+# Called by webhook-server.sh with: <repo-full-name> <commit-sha> <ref>
+set -euo pipefail
+
+REPO="$1"
+SHA="$2"
+REF="${3:-}"
+
+# Load config
+TAGBAG_CONFIG="${TAGBAG_CONFIG:-${XDG_CONFIG_HOME:-$HOME/.config}/tagbag/config}"
+# shellcheck source=/dev/null
+[[ -f "$TAGBAG_CONFIG" ]] && source "$TAGBAG_CONFIG"
+
+GITEA_URL="${GITEA_URL:-http://localhost:3000}"
+GITEA_TOKEN="${GITEA_TOKEN:-}"
+CLONE_DIR="${TAGBAG_CLONE_DIR:-$HOME/vibe/tagbag-clones}"
+
+log() { echo "[review] [$(date +%Y-%m-%dT%H:%M:%S)] $*"; }
+
+[[ -n "$GITEA_TOKEN" ]] || { log "ERROR: GITEA_TOKEN not set"; exit 1; }
+
+# Set pending commit status
+set_status() {
+    local state="$1" desc="$2"
+    curl -sf -X POST \
+        -H "Authorization: token $GITEA_TOKEN" \
+        -H "Content-Type: application/json" \
+        -d "$(jq -n --arg s "$state" --arg d "$desc" --arg c "tagbag-reviewer" --arg u "${GITEA_URL}/${REPO}" \
+            '{state: $s, description: $d, context: $c, target_url: $u}')" \
+        "${GITEA_URL}/api/v1/repos/${REPO}/statuses/${SHA}" > /dev/null
+}
+
+log "Reviewing ${REPO}@${SHA:0:8}"
+set_status "pending" "Code review in progress..."
+
+# Clone or update the repo
+REPO_DIR="${CLONE_DIR}/${REPO}"
+if [[ -d "${REPO_DIR}/.git" ]]; then
+    log "Updating existing clone..."
+    cd "$REPO_DIR"
+    git fetch origin 2>&1
+    git checkout "$SHA" 2>&1 || git checkout -b "review-${SHA:0:8}" "$SHA" 2>&1
+else
+    log "Cloning ${REPO}..."
+    mkdir -p "$(dirname "$REPO_DIR")"
+    git clone "${GITEA_URL}/${REPO}.git" "$REPO_DIR" 2>&1
+    cd "$REPO_DIR"
+    git checkout "$SHA" 2>&1 || true
+fi
+
+# Get the diff for context
+DIFF=$(git diff HEAD~1..HEAD 2>/dev/null || git show --stat HEAD 2>/dev/null || echo "Initial commit")
+
+# Run Claude Code headless for review
+REVIEW_PROMPT="You are a code reviewer. Review the following git diff thoroughly.
+
+Repository: ${REPO}
+Commit: ${SHA}
+Ref: ${REF}
+
+For each issue found, categorize as:
+- BLOCKER: Must fix before merge (security, correctness, data loss)
+- WARNING: Should fix but not blocking
+- SUGGESTION: Nice to have improvement
+
+If you find issues that don't need immediate fixing, note them as 'DEFERRED: <description>' — these will become issues.
+
+Be concise. Focus on:
+- Security vulnerabilities
+- Logic errors
+- Missing error handling at system boundaries
+- Breaking API changes
+- Performance regressions in hot paths
+
+Do NOT comment on: style preferences, missing docs on unchanged code, or hypothetical issues.
+
+Diff:
+\`\`\`
+${DIFF}
+\`\`\`"
+
+REVIEW_OUTPUT=""
+if command -v claude &>/dev/null; then
+    log "Running Claude Code review..."
+    REVIEW_OUTPUT=$(claude -p "$REVIEW_PROMPT" --model claude-opus-4-6 --max-turns 1 2>/dev/null || echo "Review failed — Claude Code not available")
+else
+    log "Claude Code not available, using basic review"
+    REVIEW_OUTPUT="Automated review skipped — Claude Code CLI not found. Install from https://claude.com/claude-code"
+fi
+
+# Check for blockers
+HAS_BLOCKERS=false
+if echo "$REVIEW_OUTPUT" | grep -qi "BLOCKER"; then
+    HAS_BLOCKERS=true
+fi
+
+# Create issues for deferred items
+ISSUE_LINKS=""
+while IFS= read -r deferred_line; do
+    if [[ -n "$deferred_line" ]]; then
+        issue_title=$(echo "$deferred_line" | sed 's/^.*DEFERRED: //' | head -c 200)
+        issue_resp=$(curl -sf -X POST \
+            -H "Authorization: token $GITEA_TOKEN" \
+            -H "Content-Type: application/json" \
+            -d "$(jq -n --arg t "$issue_title" --arg b "Found during review of ${SHA:0:8}.\n\nContext: ${REF}" \
+                '{title: $t, body: $b}')" \
+            "${GITEA_URL}/api/v1/repos/${REPO}/issues" 2>/dev/null || echo "")
+        if [[ -n "$issue_resp" ]]; then
+            issue_num=$(echo "$issue_resp" | jq -r '.number // empty')
+            issue_url=$(echo "$issue_resp" | jq -r '.html_url // empty')
+            if [[ -n "$issue_num" ]]; then
+                ISSUE_LINKS="${ISSUE_LINKS}\n- #${issue_num}: ${issue_title} (${issue_url})"
+                log "Created issue #${issue_num}: ${issue_title}"
+            fi
+        fi
+    fi
+done < <(echo "$REVIEW_OUTPUT" | grep -i "DEFERRED:" || true)
+
+# Build the review comment
+COMMENT="## Code Review — ${SHA:0:8}
+
+${REVIEW_OUTPUT}"
+
+if [[ -n "$ISSUE_LINKS" ]]; then
+    COMMENT="${COMMENT}
+
+### Created Issues
+$(echo -e "$ISSUE_LINKS")"
+fi
+
+# Post review comment on the commit
+curl -sf -X POST \
+    -H "Authorization: token $GITEA_TOKEN" \
+    -H "Content-Type: application/json" \
+    -d "$(jq -n --arg b "$COMMENT" '{body: $b}')" \
+    "${GITEA_URL}/api/v1/repos/${REPO}/git/commits/${SHA}/comments" > /dev/null 2>&1 || \
+    log "Warning: could not post commit comment"
+
+# Set final commit status
+if [[ "$HAS_BLOCKERS" == "true" ]]; then
+    set_status "failure" "Code review found blockers"
+    log "Review FAILED — blockers found"
+else
+    set_status "success" "Code review passed"
+    log "Review PASSED"
+fi
+
+log "Review complete for ${REPO}@${SHA:0:8}"

--- a/reviewer/webhook-server.sh
+++ b/reviewer/webhook-server.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# TagBag Code Reviewer — lightweight webhook receiver
+# Listens for Gitea push webhooks and queues reviews.
+#
+# Runs inside a tmux session managed by `tagbag reviewer start`.
+# Uses netcat to listen on a port, no external dependencies.
+set -euo pipefail
+
+REVIEW_PORT="${TAGBAG_REVIEW_PORT:-9876}"
+REVIEW_QUEUE="${TAGBAG_CONFIG_DIR:-$HOME/.config/tagbag}/review-queue"
+REVIEW_LOG="${TAGBAG_CONFIG_DIR:-$HOME/.config/tagbag}/reviewer.log"
+
+mkdir -p "$(dirname "$REVIEW_QUEUE")"
+: > "$REVIEW_QUEUE"
+
+log() { echo "[$(date +%Y-%m-%dT%H:%M:%S)] $*" | tee -a "$REVIEW_LOG"; }
+
+log "TagBag Code Reviewer starting on port ${REVIEW_PORT}"
+log "Queue: ${REVIEW_QUEUE}"
+log "Log: ${REVIEW_LOG}"
+
+# Process review queue in background
+process_queue() {
+    while true; do
+        if [[ -s "$REVIEW_QUEUE" ]]; then
+            local line
+            line=$(head -1 "$REVIEW_QUEUE")
+            sed -i '' '1d' "$REVIEW_QUEUE" 2>/dev/null || tail -n +2 "$REVIEW_QUEUE" > "${REVIEW_QUEUE}.tmp" && mv "${REVIEW_QUEUE}.tmp" "$REVIEW_QUEUE"
+            if [[ -n "$line" ]]; then
+                log "Processing: $line"
+                # shellcheck disable=SC2086
+                bash "$(dirname "$0")/do-review.sh" $line 2>&1 | tee -a "$REVIEW_LOG" || true
+            fi
+        fi
+        sleep 2
+    done
+}
+process_queue &
+QUEUE_PID=$!
+trap 'kill $QUEUE_PID 2>/dev/null; log "Reviewer stopped"' EXIT
+
+# Listen for webhooks
+while true; do
+    # Use a simple HTTP response
+    response="HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok"
+
+    # Read the webhook payload via a temp fifo
+    tmpfifo=$(mktemp -u)
+    mkfifo "$tmpfifo"
+
+    # Listen for one connection
+    (echo -e "$response" | nc -l "$REVIEW_PORT" > "$tmpfifo" 2>/dev/null) &
+    NC_PID=$!
+
+    # Read the body
+    payload=""
+    if timeout 300 cat "$tmpfifo" 2>/dev/null; then
+        payload=$(cat "$tmpfifo" 2>/dev/null || true)
+    fi
+    rm -f "$tmpfifo"
+    wait $NC_PID 2>/dev/null || true
+
+    # Parse the payload — extract repo full_name and commit SHA
+    if [[ -n "$payload" ]]; then
+        # Try to extract JSON body (after the blank line in HTTP request)
+        json_body=$(echo "$payload" | sed -n '/^\r*$/,$ p' | tail -n +2)
+        if [[ -n "$json_body" ]]; then
+            repo=$(echo "$json_body" | jq -r '.repository.full_name // empty' 2>/dev/null)
+            sha=$(echo "$json_body" | jq -r '.after // empty' 2>/dev/null)
+            ref=$(echo "$json_body" | jq -r '.ref // empty' 2>/dev/null)
+            if [[ -n "$repo" && -n "$sha" ]]; then
+                log "Webhook received: ${repo} ${sha} ${ref}"
+                echo "${repo} ${sha} ${ref}" >> "$REVIEW_QUEUE"
+            fi
+        fi
+    fi
+done


### PR DESCRIPTION
## Summary
- Webhook server listens for Gitea push events (no polling)
- Clones repo to configurable dir, runs Claude Code headless review
- Posts 1 review comment per push with BLOCKER/WARNING/SUGGESTION
- Sets Gitea commit status to block or allow PR merges
- Creates issues for deferred findings, links in review comment
- `tagbag reviewer start|stop|status|logs|register`

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)