### PR TITLE
Add tagbag database schema for coordination layer

### DIFF
--- a/db/migrate.sh
+++ b/db/migrate.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+PGPASSWORD=plane psql -h localhost -U plane -d tagbag -f "$SCRIPT_DIR/migrations/001_initial.sql"

--- a/db/migrate.sh
+++ b/db/migrate.sh
@@ -3,4 +3,4 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 
-PGPASSWORD=plane psql -h localhost -U plane -d tagbag -f "$SCRIPT_DIR/migrations/001_initial.sql"
+PGPASSWORD=${PGPASSWORD:-plane} psql -h "${PGHOST:-localhost}" -U "${PGUSER:-plane}" -d "${PGDATABASE:-tagbag}" -f "$SCRIPT_DIR/migrations/001_initial.sql"

--- a/db/migrations/001_initial.sql
+++ b/db/migrations/001_initial.sql
@@ -1,0 +1,42 @@
+-- tagbag coordination layer schema
+-- Migration 001: initial tables
+
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS webhook_events (
+    id          SERIAL PRIMARY KEY,
+    event_type  TEXT NOT NULL,
+    repo        TEXT NOT NULL,
+    payload_hash TEXT NOT NULL,
+    processed_at TIMESTAMPTZ,
+    created_at  TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS cross_links (
+    id           SERIAL PRIMARY KEY,
+    source_type  TEXT NOT NULL,  -- commit, pr, branch
+    source_id    TEXT NOT NULL,
+    source_repo  TEXT NOT NULL,
+    target_type  TEXT NOT NULL,  -- work_item
+    target_id    TEXT NOT NULL,
+    target_project TEXT NOT NULL,
+    created_at   TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS activity_log (
+    id           SERIAL PRIMARY KEY,
+    event_type   TEXT NOT NULL,
+    repo         TEXT NOT NULL,
+    ref          TEXT,
+    actor        TEXT,
+    summary      TEXT,
+    details_json JSONB,
+    created_at   TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- Indexes
+CREATE INDEX IF NOT EXISTS idx_webhook_events_repo_hash ON webhook_events (repo, payload_hash);
+CREATE INDEX IF NOT EXISTS idx_cross_links_target_id    ON cross_links (target_id);
+CREATE INDEX IF NOT EXISTS idx_activity_log_created_at  ON activity_log (created_at);
+
+COMMIT;

--- a/db/migrations/001_initial.sql
+++ b/db/migrations/001_initial.sql
@@ -14,10 +14,10 @@ CREATE TABLE IF NOT EXISTS webhook_events (
 
 CREATE TABLE IF NOT EXISTS cross_links (
     id           SERIAL PRIMARY KEY,
-    source_type  TEXT NOT NULL,  -- commit, pr, branch
+    source_type  TEXT NOT NULL CHECK (source_type IN ('commit', 'pr', 'branch')),  -- commit, pr, branch
     source_id    TEXT NOT NULL,
     source_repo  TEXT NOT NULL,
-    target_type  TEXT NOT NULL,  -- work_item
+    target_type  TEXT NOT NULL CHECK (target_type IN ('work_item')),  -- work_item
     target_id    TEXT NOT NULL,
     target_project TEXT NOT NULL,
     created_at   TIMESTAMPTZ NOT NULL DEFAULT now()
@@ -30,13 +30,16 @@ CREATE TABLE IF NOT EXISTS activity_log (
     ref          TEXT,
     actor        TEXT,
     summary      TEXT,
+    identifier   TEXT,
     details_json JSONB,
     created_at   TIMESTAMPTZ NOT NULL DEFAULT now()
 );
 
 -- Indexes
-CREATE INDEX IF NOT EXISTS idx_webhook_events_repo_hash ON webhook_events (repo, payload_hash);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_webhook_events_repo_hash ON webhook_events (repo, payload_hash);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_cross_links_source_target ON cross_links (source_type, source_id, source_repo, target_id);
 CREATE INDEX IF NOT EXISTS idx_cross_links_target_id    ON cross_links (target_id);
 CREATE INDEX IF NOT EXISTS idx_activity_log_created_at  ON activity_log (created_at);
+CREATE INDEX IF NOT EXISTS idx_activity_log_identifier  ON activity_log (identifier);
 
 COMMIT;


### PR DESCRIPTION
## Summary
- Add initial SQL migration (`db/migrations/001_initial.sql`) with three tables: `webhook_events` (dedup via payload_hash), `cross_links` (commit/PR/branch to work_item mapping), and `activity_log` (JSONB details)
- Add `db/migrate.sh` to run migrations against the tagbag database
- Indexes on `(repo, payload_hash)`, `(target_id)`, and `(created_at)`

Closes #30

## Test plan
- [ ] `docker compose up -d` to start Postgres
- [ ] `bash db/migrate.sh` succeeds without errors
- [ ] Verify tables exist: `PGPASSWORD=plane psql -h localhost -U plane -d tagbag -c '\dt'`
- [ ] Run migrate.sh a second time to confirm idempotency (IF NOT EXISTS)

🤖 Generated with [Claude Code](https://claude.com/claude-code)