### PR TITLE
Update README.md and CLI reference docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,11 +79,11 @@ Open the dashboard at [localhost:8888](http://localhost:8888) for a unified view
 
 ### Reviewer
 
-The **reviewer** is an AI-powered code review service. It watches Gitea pull requests and provides automated review comments. Use `tagbag reviewer register` to set up the webhook and `tagbag reviewer protect` to enforce reviews on branches.
+The **reviewer** is an AI-powered code review service. It watches Gitea push events, provides automated review comments on commits, and sets commit statuses. Use `tagbag reviewer register` to set up the webhook and `tagbag reviewer protect` to enforce reviews on branches.
 
 ### Bridge
 
-The **bridge** syncs repositories between GitHub and Gitea. Use `tagbag bridge register` to set up the webhook for automatic mirroring.
+The **bridge** links Gitea events to Plane work items. It parses commit messages and pull requests for references like `PROJ-123` and adds comments to the corresponding work items. Use `tagbag bridge register` to set up the webhook for a repository.
 
 Run `./cli/tagbag --help` for the full command tree. Every subcommand has `--help`.
 

--- a/README.md
+++ b/README.md
@@ -2,15 +2,29 @@
 
 Self-hosted GitHub replacement. Built from source. All the keys to the castle.
 
+**Current version: v0.12.0**
+
 ## What
 
-Three forked open-source projects, one Docker Compose stack, one unified CLI.
+Three forked open-source projects, one Docker Compose stack, one unified CLI, one dashboard.
 
 | Service | Replaces | Port | Source |
 |---|---|---|---|
+| [TagBag Dashboard](http://localhost:8888) | Unified web UI | [localhost:8888](http://localhost:8888) | `web/index.html` |
 | [Gitea](https://gitea.io) | Code, PRs, Code Review | [localhost:3000](http://localhost:3000) | `submodules/gitea/` |
 | [Plane](https://plane.so) | Issues, Sprints, Projects | [localhost:8080](http://localhost:8080) | `submodules/plane/` |
 | [Woodpecker CI](https://woodpecker-ci.org) | Actions, CI/CD | [localhost:9080](http://localhost:9080) | `submodules/woodpecker/` |
+
+### Full Port Map
+
+| Port | Service |
+|---|---|
+| 3000 | Gitea (HTTP) |
+| 8080 | Plane |
+| 9080 | Woodpecker CI |
+| 8888 | TagBag Dashboard |
+| 5432 | PostgreSQL |
+| 2222 | Gitea SSH |
 
 All backed by PostgreSQL. Gitea is the OAuth2 identity provider for single sign-on.
 
@@ -30,16 +44,46 @@ First build takes a while (Go, Python, Node.js compiling from source). After tha
 ./cli/tagbag down                  # stop
 ```
 
+Open the dashboard at [localhost:8888](http://localhost:8888) for a unified view of code, issues, PRs, and CI.
+
 ## CLI
 
 ```bash
+# Identity
 ./cli/tagbag login                 # set up tokens for all three services
 ./cli/tagbag whoami                # show identity across services
 
+# Infrastructure
+./cli/tagbag status                # show all service status + endpoints
+./cli/tagbag up                    # docker compose up -d
+./cli/tagbag down                  # docker compose down
+./cli/tagbag build                 # rebuild all from source
+./cli/tagbag logs                  # tail all logs
+
+# Git operations
+./cli/tagbag clone <owner/repo>    # clone a Gitea repo
+./cli/tagbag web                   # open Gitea repo in browser
+./cli/tagbag push <owner/repo>     # push repo to Gitea (supports --github, --mirror)
+
+# Service CLIs
 ./cli/tagbag plane work-items ...  # issues, sprints, modules
 ./cli/tagbag gitea prs ...         # repos, pull requests, code review
 ./cli/tagbag ci pipelines ...      # CI/CD pipelines, secrets, logs
+
+# AI Code Review
+./cli/tagbag reviewer start|stop|status|logs|register|protect
+
+# GitHub-Gitea Bridge
+./cli/tagbag bridge start|stop|status|logs|register
 ```
+
+### Reviewer
+
+The **reviewer** is an AI-powered code review service. It watches Gitea pull requests and provides automated review comments. Use `tagbag reviewer register` to set up the webhook and `tagbag reviewer protect` to enforce reviews on branches.
+
+### Bridge
+
+The **bridge** syncs repositories between GitHub and Gitea. Use `tagbag bridge register` to set up the webhook for automatic mirroring.
 
 Run `./cli/tagbag --help` for the full command tree. Every subcommand has `--help`.
 

--- a/docs/tagbag-cli.md
+++ b/docs/tagbag-cli.md
@@ -229,6 +229,106 @@ export PLANE_API_TOKEN="..."
 export WOODPECKER_TOKEN="..."
 ```
 
+## Git Operations
+
+### clone
+
+Clone a Gitea repository by owner/repo shorthand.
+
+```bash
+tagbag clone <owner/repo> [path] [--ssh]
+```
+
+| Argument / Option | Description |
+|---|---|
+| `<owner/repo>` | Repository to clone (e.g. `bedwards/my-project`) |
+| `[path]` | Optional local directory to clone into (defaults to repo name) |
+| `--ssh` | Clone via SSH (`ssh://git@localhost:2222`) instead of HTTP |
+
+Examples:
+
+```bash
+tagbag clone bedwards/my-project                    # clone via HTTP to ./my-project
+tagbag clone bedwards/my-project ~/src/myproj       # clone to custom path
+tagbag clone bedwards/my-project --ssh              # clone via SSH (port 2222)
+```
+
+### web
+
+Open the current repository's Gitea page in the default browser. Must be run from within a Gitea-hosted git repo.
+
+```bash
+tagbag web
+```
+
+### push
+
+Push a local repository to Gitea, with options for GitHub mirroring.
+
+```bash
+tagbag push <owner/repo> [options]
+```
+
+| Option | Description |
+|---|---|
+| `--github` | Also push to GitHub |
+| `--create` | Create the remote repository if it doesn't exist |
+| `--private` | Make the created repository private |
+| `--mirror` | Set up as a mirror (read-only copy) |
+| `--branch <name>` | Push only this branch (default: all branches) |
+| `--no-tags` | Don't push tags |
+
+Examples:
+
+```bash
+tagbag push bedwards/my-project --create --private   # create private repo and push
+tagbag push bedwards/my-project --github              # push to both Gitea and GitHub
+tagbag push bedwards/my-project --mirror              # set up as mirror
+tagbag push bedwards/my-project --branch main --no-tags  # push only main, skip tags
+```
+
+## Reviewer Commands (AI Code Review)
+
+The reviewer is an AI-powered code review service that watches Gitea pull requests and posts automated review comments.
+
+```bash
+tagbag reviewer start                # start the reviewer service
+tagbag reviewer stop                 # stop the reviewer service
+tagbag reviewer status               # check if the reviewer is running
+tagbag reviewer logs                 # tail reviewer logs
+tagbag reviewer register             # register the Gitea webhook for PR events
+tagbag reviewer protect              # enable branch protection requiring reviewer approval
+```
+
+| Subcommand | Description |
+|---|---|
+| `start` | Start the reviewer container |
+| `stop` | Stop the reviewer container |
+| `status` | Show whether the reviewer is running and healthy |
+| `logs` | Tail the reviewer service logs |
+| `register` | Create a Gitea webhook on the current repo so the reviewer receives PR events |
+| `protect` | Enable branch protection rules that require the reviewer's approval before merge |
+
+## Bridge Commands (GitHub-Gitea Sync)
+
+The bridge syncs repositories between GitHub and Gitea, enabling automatic mirroring and bi-directional webhook forwarding.
+
+```bash
+tagbag bridge start                  # start the bridge service
+tagbag bridge stop                   # stop the bridge service
+tagbag bridge status                 # check if the bridge is running
+tagbag bridge logs                   # tail bridge logs
+tagbag bridge register               # register webhooks for sync
+```
+
+| Subcommand | Description |
+|---|---|
+| `start` | Start the bridge container |
+| `stop` | Stop the bridge container |
+| `status` | Show whether the bridge is running and healthy |
+| `logs` | Tail the bridge service logs |
+| `register` | Set up webhooks on both GitHub and Gitea for automatic repository syncing |
+
 ## Architecture
 
 The CLI is a bash script that:

--- a/docs/tagbag-cli.md
+++ b/docs/tagbag-cli.md
@@ -255,7 +255,7 @@ tagbag clone bedwards/my-project --ssh              # clone via SSH (port 2222)
 
 ### web
 
-Open the current repository's Gitea page in the default browser. Must be run from within a Gitea-hosted git repo.
+Open the TagBag dashboard in the default browser.
 
 ```bash
 tagbag web
@@ -274,7 +274,7 @@ tagbag push <owner/repo> [options]
 | `--github` | Also push to GitHub |
 | `--create` | Create the remote repository if it doesn't exist |
 | `--private` | Make the created repository private |
-| `--mirror` | Set up as a mirror (read-only copy) |
+| `--mirror` | Set up a push mirror in Gitea for ongoing sync |
 | `--branch <name>` | Push only this branch (default: all branches) |
 | `--no-tags` | Don't push tags |
 
@@ -289,7 +289,7 @@ tagbag push bedwards/my-project --branch main --no-tags  # push only main, skip 
 
 ## Reviewer Commands (AI Code Review)
 
-The reviewer is an AI-powered code review service that watches Gitea pull requests and posts automated review comments.
+The reviewer is an AI-powered code review service that watches Gitea push events and posts automated review comments on commits.
 
 ```bash
 tagbag reviewer start                # start the reviewer service
@@ -306,12 +306,12 @@ tagbag reviewer protect              # enable branch protection requiring review
 | `stop` | Stop the reviewer container |
 | `status` | Show whether the reviewer is running and healthy |
 | `logs` | Tail the reviewer service logs |
-| `register` | Create a Gitea webhook on the current repo so the reviewer receives PR events |
+| `register` | Create a Gitea webhook on the current repo so the reviewer receives push events |
 | `protect` | Enable branch protection rules that require the reviewer's approval before merge |
 
-## Bridge Commands (GitHub-Gitea Sync)
+## Bridge Commands (Gitea-Plane Integration)
 
-The bridge syncs repositories between GitHub and Gitea, enabling automatic mirroring and bi-directional webhook forwarding.
+The bridge links Gitea events (commits, PRs) to Plane work items. It parses commit messages and PRs for references like `PROJ-123` and adds comments and links to the corresponding work items in Plane.
 
 ```bash
 tagbag bridge start                  # start the bridge service
@@ -327,7 +327,7 @@ tagbag bridge register               # register webhooks for sync
 | `stop` | Stop the bridge container |
 | `status` | Show whether the bridge is running and healthy |
 | `logs` | Tail the bridge service logs |
-| `register` | Set up webhooks on both GitHub and Gitea for automatic repository syncing |
+| `register` | Set up a Gitea webhook to send repository events to the bridge for Plane integration |
 
 ## Architecture
 


### PR DESCRIPTION
## Summary
- Updated README.md with dashboard (localhost:8888), full port map (3000, 8080, 9080, 8888, 5432, 2222), all CLI commands, reviewer/bridge feature descriptions, and version v0.12.0
- Updated docs/tagbag-cli.md with detailed documentation for `clone`, `web`, `push`, `reviewer`, and `bridge` commands including options, arguments, and examples

Closes #22, Closes #23

## Test plan
- [ ] Verify all port numbers match docker-compose.yml
- [ ] Verify CLI command names match `tagbag --help` output
- [ ] Verify push options match actual implementation
- [ ] Review reviewer and bridge subcommand descriptions for accuracy

🤖 Generated with [Claude Code](https://claude.com/claude-code)