### PR TITLE
add TLS termination via Caddy gateway

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -55,3 +55,10 @@ WOODPECKER_DB_NAME=woodpecker
 # Set after creating OAuth app in Gitea (see setup.sh)
 WOODPECKER_GITEA_CLIENT=
 WOODPECKER_GITEA_SECRET=
+
+# =============================================================================
+# TLS Gateway (optional, enable with: docker compose --profile tls up -d)
+# =============================================================================
+TAGBAG_DOMAIN=localhost
+# Use 'internal' for self-signed, or omit for auto Let's Encrypt
+TAGBAG_TLS_MODE=internal

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -314,6 +314,35 @@ services:
     networks:
       - tagbag
 
+  # ===========================================================================
+  # TLS Gateway (Caddy)
+  # Port 443 (HTTPS), 80 (HTTP redirect)
+  # Enable with: docker compose --profile tls up -d
+  # ===========================================================================
+
+  caddy-gateway:
+    image: caddy:2-alpine
+    restart: always
+    profiles:
+      - tls
+    volumes:
+      - ./docker/Caddyfile.gateway:/etc/caddy/Caddyfile:ro
+      - caddy-data:/data
+      - caddy-config:/config
+    ports:
+      - "443:443"
+      - "80:80"
+    environment:
+      TAGBAG_DOMAIN: ${TAGBAG_DOMAIN:-localhost}
+      TAGBAG_TLS_MODE: ${TAGBAG_TLS_MODE:-internal}
+    depends_on:
+      - gitea
+      - plane-proxy
+      - woodpecker-server
+      - tagbag-web
+    networks:
+      - tagbag
+
 # =============================================================================
 # Volumes
 # =============================================================================
@@ -325,6 +354,8 @@ volumes:
   rabbitmq_data:
   uploads:
   woodpecker-data:
+  caddy-data:
+  caddy-config:
 
 # =============================================================================
 # Networks

--- a/docker/Caddyfile.gateway
+++ b/docker/Caddyfile.gateway
@@ -1,0 +1,51 @@
+# TagBag TLS Gateway
+# Terminates TLS and reverse-proxies to all services.
+# For local dev: uses internal self-signed certs (tls internal)
+# For production: set TAGBAG_DOMAIN=yourdomain.com in .env for auto Let's Encrypt
+
+{$TAGBAG_DOMAIN:localhost} {
+	tls {$TAGBAG_TLS_MODE:internal}
+
+	# Gitea — code hosting, PRs, code review
+	reverse_proxy /gitea/* gitea:3000
+	handle_path /gitea {
+		redir /gitea/ permanent
+	}
+
+	# Plane — issues, sprints, project management
+	reverse_proxy /plane/* plane-proxy:80
+	handle_path /plane {
+		redir /plane/ permanent
+	}
+
+	# Woodpecker — CI/CD pipelines
+	reverse_proxy /ci/* woodpecker-server:8000
+	handle_path /ci {
+		redir /ci/ permanent
+	}
+
+	# Direct service ports (for API-only access)
+	reverse_proxy /api/gitea/* gitea:3000
+	reverse_proxy /api/plane/* plane-api:8000
+	reverse_proxy /api/woodpecker/* woodpecker-server:8000
+
+	# Dashboard — unified web UI (default / catch-all)
+	reverse_proxy /* tagbag-web:80
+
+	# Security headers
+	header {
+		X-Frame-Options DENY
+		X-Content-Type-Options nosniff
+		Referrer-Policy strict-origin-when-cross-origin
+		Strict-Transport-Security "max-age=31536000; includeSubDomains"
+		-Server
+	}
+
+	log {
+		output file /data/access.log {
+			roll_size 10mb
+			roll_keep 5
+		}
+		format json
+	}
+}


### PR DESCRIPTION
## Summary
- **docker/Caddyfile.gateway**: Caddy reverse proxy config with auto-TLS, routing `/gitea/`, `/plane/`, `/ci/`, and `/` (dashboard)
- **docker-compose.yml**: New `caddy-gateway` service behind `tls` profile (opt-in)
- **.env.example**: Added `TAGBAG_DOMAIN` and `TAGBAG_TLS_MODE` config vars

Uses self-signed certs by default for local dev. Set `TAGBAG_DOMAIN` to a real domain for automatic Let's Encrypt.

Closes #32

## Test plan
- [ ] `docker compose --profile tls up -d caddy-gateway` — verify starts
- [ ] `curl -k https://localhost` — verify dashboard loads over HTTPS
- [ ] `curl -k https://localhost/gitea/api/v1/settings/api` — verify proxy works
- [ ] Normal `docker compose up -d` without `--profile tls` — verify gateway doesn't start

🤖 Generated with [Claude Code](https://claude.com/claude-code)