### PR TITLE
Dashboard: handle service downtime gracefully with error states

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -159,7 +159,70 @@ body::before {
 }
 
 .dot.ok { background: var(--green); box-shadow: 0 0 6px rgba(61, 214, 140, 0.4); }
+.dot.warn { background: var(--yellow); box-shadow: 0 0 6px rgba(232, 200, 72, 0.4); }
 .dot.err { background: var(--red); box-shadow: 0 0 6px rgba(240, 72, 72, 0.4); }
+
+.status-dot { position: relative; cursor: default; }
+.status-dot .tooltip {
+  display: none;
+  position: absolute;
+  top: calc(100% + 8px);
+  left: 50%;
+  transform: translateX(-50%);
+  background: var(--bg-elevated);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 6px 10px;
+  font-size: 0.7rem;
+  color: var(--text-secondary);
+  white-space: nowrap;
+  z-index: 150;
+  pointer-events: none;
+  box-shadow: 0 4px 12px rgba(0,0,0,0.3);
+}
+.status-dot:hover .tooltip { display: block; }
+
+/* ═══ Error panel ═══ */
+.error-panel {
+  text-align: center;
+  padding: 3rem 2rem;
+  color: var(--text-secondary);
+  font-family: var(--mono);
+  font-size: 0.85rem;
+}
+.error-panel .error-icon {
+  font-size: 2rem;
+  margin-bottom: 0.75rem;
+  color: var(--red);
+  opacity: 0.6;
+}
+.error-panel .error-title {
+  font-weight: 600;
+  color: var(--red);
+  margin-bottom: 0.5rem;
+  font-size: 0.9rem;
+}
+.error-panel .error-detail {
+  color: var(--text-muted);
+  font-size: 0.8rem;
+  margin-bottom: 1rem;
+}
+.btn-retry {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 14px;
+  border-radius: var(--radius);
+  font-family: var(--mono);
+  font-size: 0.75rem;
+  font-weight: 500;
+  cursor: pointer;
+  border: 1px solid var(--border);
+  background: var(--bg-elevated);
+  color: var(--text-secondary);
+  transition: all var(--transition);
+}
+.btn-retry:hover { border-color: var(--accent-dim); color: var(--accent); }
 
 .settings-btn {
   background: none;
@@ -465,9 +528,9 @@ body::before {
   </div>
 
   <div class="status-rail" id="statusRail">
-    <div class="status-dot"><span class="dot" id="dotGitea"></span>Gitea</div>
-    <div class="status-dot"><span class="dot" id="dotPlane"></span>Plane</div>
-    <div class="status-dot"><span class="dot" id="dotWoodpecker"></span>CI</div>
+    <div class="status-dot"><span class="dot" id="dotGitea"></span>Gitea<span class="tooltip" id="tipGitea">Checking...</span></div>
+    <div class="status-dot"><span class="dot" id="dotPlane"></span>Plane<span class="tooltip" id="tipPlane">Checking...</span></div>
+    <div class="status-dot"><span class="dot" id="dotWoodpecker"></span>CI<span class="tooltip" id="tipWoodpecker">Checking...</span></div>
   </div>
 
   <button class="settings-btn" onclick="toggleSettings()">&#x2699; Config</button>
@@ -629,13 +692,34 @@ function saveSettings() {
   loadAll();
 }
 
-// ═══ API helpers ═══
+// ═══ Service health state ═══
+const serviceHealth = {
+  gitea: { status: 'unknown', lastCheck: null, responseTime: null, httpStatus: null },
+  plane: { status: 'unknown', lastCheck: null, responseTime: null, httpStatus: null },
+  woodpecker: { status: 'unknown', lastCheck: null, responseTime: null, httpStatus: null },
+};
+
+// ═══ API helpers with timeout and error detail ═══
+async function fetchWithTimeout(url, options = {}, timeoutMs = 10000) {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const r = await fetch(url, { ...options, signal: controller.signal });
+    clearTimeout(timer);
+    return r;
+  } catch (e) {
+    clearTimeout(timer);
+    if (e.name === 'AbortError') throw new Error('Request timed out');
+    throw e;
+  }
+}
+
 async function giteaFetch(path) {
   const c = getConfig();
   const headers = { 'Content-Type': 'application/json' };
   if (c.giteaToken) headers['Authorization'] = `token ${c.giteaToken}`;
-  const r = await fetch(`${c.giteaUrl}/api/v1${path}`, { headers });
-  if (!r.ok) throw new Error(`Gitea ${r.status}`);
+  const r = await fetchWithTimeout(`${c.giteaUrl}/api/v1${path}`, { headers });
+  if (!r.ok) throw new Error(`Gitea HTTP ${r.status}: ${r.statusText}`);
   return r.json();
 }
 
@@ -643,8 +727,8 @@ async function planeFetch(path) {
   const c = getConfig();
   const headers = { 'Content-Type': 'application/json' };
   if (c.planeToken) headers['X-Api-Key'] = c.planeToken;
-  const r = await fetch(`${c.planeUrl}/api/v1${path}`, { headers });
-  if (!r.ok) throw new Error(`Plane ${r.status}`);
+  const r = await fetchWithTimeout(`${c.planeUrl}/api/v1${path}`, { headers });
+  if (!r.ok) throw new Error(`Plane HTTP ${r.status}: ${r.statusText}`);
   return r.json();
 }
 
@@ -652,8 +736,8 @@ async function woodpeckerFetch(path) {
   const c = getConfig();
   const headers = { 'Content-Type': 'application/json' };
   if (c.woodpeckerToken) headers['Authorization'] = `Bearer ${c.woodpeckerToken}`;
-  const r = await fetch(`${c.woodpeckerUrl}/api${path}`, { headers });
-  if (!r.ok) throw new Error(`Woodpecker ${r.status}`);
+  const r = await fetchWithTimeout(`${c.woodpeckerUrl}/api${path}`, { headers });
+  if (!r.ok) throw new Error(`Woodpecker HTTP ${r.status}: ${r.statusText}`);
   return r.json();
 }
 
@@ -681,34 +765,93 @@ function escHtml(s) {
   return s ? s.replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;') : '';
 }
 
+function formatTime(date) {
+  if (!date) return 'never';
+  return date.toLocaleTimeString();
+}
+
 // ═══ Tab switching ═══
 function switchTab(view) {
   document.querySelectorAll('.nav-tab').forEach(t => t.classList.toggle('active', t.dataset.view === view));
   document.querySelectorAll('.view').forEach(v => v.classList.toggle('active', v.id === `view${view.charAt(0).toUpperCase() + view.slice(1)}`));
 }
 
-// ═══ Health checks ═══
+// ═══ Error panel helper ═══
+function showError(loadingId, tableId, icon, serviceName, error, retryFn) {
+  const el = document.getElementById(loadingId);
+  const detail = error.message.includes('timed out') ? 'Connection timed out - service may be starting up'
+    : error.message.includes('Failed to fetch') || error.message.includes('NetworkError') ? 'Service is unreachable - check if it is running'
+    : error.message;
+  el.innerHTML = `
+    <div class="error-panel">
+      <div class="error-icon">${icon}</div>
+      <div class="error-title">Service unavailable</div>
+      <div class="error-detail">${escHtml(serviceName)}: ${escHtml(detail)}</div>
+      <button class="btn-retry" onclick="${retryFn}">&#x21BB; Retry</button>
+    </div>`;
+  el.style.display = '';
+  if (tableId) document.getElementById(tableId).style.display = 'none';
+}
+
+// Reset a view to loading state
+function showLoading(loadingId, tableId, message) {
+  const el = document.getElementById(loadingId);
+  el.innerHTML = `<div class="spinner"></div> ${escHtml(message)}`;
+  el.className = 'loading';
+  el.style.display = '';
+  if (tableId) document.getElementById(tableId).style.display = 'none';
+}
+
+// ═══ Health checks with retry and status detail ═══
 async function checkHealth() {
-  const urls = [
-    ['dotGitea', `${DEFAULTS.giteaUrl}/api/v1/settings/api`],
-    ['dotPlane', `${DEFAULTS.planeUrl}/api/instances/`],
-    ['dotWoodpecker', `${DEFAULTS.woodpeckerUrl}/api/version`],
+  const checks = [
+    { key: 'gitea', dotId: 'dotGitea', tipId: 'tipGitea', url: `${getConfig().giteaUrl}/api/v1/settings/api`, label: 'Gitea' },
+    { key: 'plane', dotId: 'dotPlane', tipId: 'tipPlane', url: `${getConfig().planeUrl}/api/instances/`, label: 'Plane' },
+    { key: 'woodpecker', dotId: 'dotWoodpecker', tipId: 'tipWoodpecker', url: `${getConfig().woodpeckerUrl}/api/version`, label: 'Woodpecker' },
   ];
-  for (const [id, url] of urls) {
+  const results = await Promise.allSettled(checks.map(async (svc) => {
+    const start = performance.now();
     try {
-      const r = await fetch(url);
-      document.getElementById(id).className = r.ok ? 'dot ok' : 'dot err';
-    } catch {
-      document.getElementById(id).className = 'dot err';
+      const r = await fetchWithTimeout(svc.url, {}, 8000);
+      const elapsed = Math.round(performance.now() - start);
+      const h = serviceHealth[svc.key];
+      h.lastCheck = new Date();
+      h.responseTime = elapsed;
+      h.httpStatus = r.status;
+      if (r.ok) {
+        h.status = 'ok';
+        document.getElementById(svc.dotId).className = 'dot ok';
+        document.getElementById(svc.tipId).textContent = `Healthy (${elapsed}ms) - ${formatTime(h.lastCheck)}`;
+      } else {
+        // Service responded but with an error (degraded)
+        h.status = r.status >= 500 ? 'err' : 'warn';
+        document.getElementById(svc.dotId).className = r.status >= 500 ? 'dot err' : 'dot warn';
+        document.getElementById(svc.tipId).textContent = `HTTP ${r.status} (${elapsed}ms) - ${formatTime(h.lastCheck)}`;
+      }
+    } catch (e) {
+      const elapsed = Math.round(performance.now() - start);
+      const h = serviceHealth[svc.key];
+      h.lastCheck = new Date();
+      h.responseTime = elapsed;
+      h.httpStatus = null;
+      h.status = 'err';
+      document.getElementById(svc.dotId).className = 'dot err';
+      const reason = e.message.includes('timed out') ? 'Timeout' : 'Unreachable';
+      document.getElementById(svc.tipId).textContent = `${reason} - ${formatTime(h.lastCheck)}`;
     }
-  }
+  }));
 }
 
 // ═══ Load: Code (repos) ═══
 async function loadCode() {
+  showLoading('loadingCode', 'tableCode', 'Loading repositories...');
   try {
     const repos = await giteaFetch('/user/repos?sort=updated&limit=50');
     const body = document.getElementById('bodyCode');
+    if (!repos.length) {
+      document.getElementById('loadingCode').innerHTML = '<div class="empty"><div class="empty-icon">&#x2630;</div>No repositories found</div>';
+      return;
+    }
     body.innerHTML = repos.map(r => `
       <tr>
         <td>
@@ -724,12 +867,13 @@ async function loadCode() {
     document.getElementById('loadingCode').style.display = 'none';
     document.getElementById('tableCode').style.display = 'table';
   } catch (e) {
-    document.getElementById('loadingCode').innerHTML = `<div class="empty"><div class="empty-icon">&#x2630;</div>Could not load repos. ${escHtml(e.message)}</div>`;
+    showError('loadingCode', 'tableCode', '&#x2630;', 'Gitea', e, 'loadCode()');
   }
 }
 
 // ═══ Load: Commits ═══
 async function loadCommits() {
+  showLoading('loadingCommits', 'tableCommits', 'Loading commits...');
   try {
     const repos = await giteaFetch('/user/repos?sort=updated&limit=10');
     let allCommits = [];
@@ -737,11 +881,15 @@ async function loadCommits() {
       try {
         const commits = await giteaFetch(`/repos/${r.full_name}/commits?limit=10`);
         allCommits.push(...commits.map(c => ({ ...c, repo: r.full_name })));
-      } catch {}
+      } catch { /* individual repo failure is non-fatal */ }
     }
     allCommits.sort((a, b) => new Date(b.created) - new Date(a.created));
     allCommits = allCommits.slice(0, 30);
     const body = document.getElementById('bodyCommits');
+    if (!allCommits.length) {
+      document.getElementById('loadingCommits').innerHTML = '<div class="empty"><div class="empty-icon">&#x2B24;</div>No commits found</div>';
+      return;
+    }
     body.innerHTML = allCommits.map(c => `
       <tr>
         <td><span class="commit-sha">${c.sha?.substring(0, 7) || '?'}</span></td>
@@ -755,7 +903,7 @@ async function loadCommits() {
     document.getElementById('loadingCommits').style.display = 'none';
     document.getElementById('tableCommits').style.display = 'table';
   } catch (e) {
-    document.getElementById('loadingCommits').innerHTML = `<div class="empty"><div class="empty-icon">&#x2B24;</div>${escHtml(e.message)}</div>`;
+    showError('loadingCommits', 'tableCommits', '&#x2B24;', 'Gitea', e, 'loadCommits()');
   }
 }
 
@@ -766,6 +914,7 @@ async function loadIssues() {
     document.getElementById('loadingIssues').innerHTML = '<div class="empty"><div class="empty-icon">&#x25CB;</div>Configure Plane token and workspace in Settings</div>';
     return;
   }
+  showLoading('loadingIssues', 'tableIssues', 'Loading work items...');
   try {
     const projects = await planeFetch(`/workspaces/${c.planeWorkspace}/projects/`);
     const projectList = projects.results || projects || [];
@@ -775,11 +924,15 @@ async function loadIssues() {
         const items = await planeFetch(`/workspaces/${c.planeWorkspace}/projects/${p.id}/work-items/?expand=state,assignees`);
         const results = items.results || items || [];
         allIssues.push(...results.map(i => ({ ...i, project_identifier: p.identifier })));
-      } catch {}
+      } catch { /* individual project failure is non-fatal */ }
     }
     const stateGroup = { backlog: 'badge-muted', unstarted: 'badge-muted', started: 'badge-blue', completed: 'badge-green', cancelled: 'badge-red' };
     const priorityClass = { urgent: 'priority-urgent', high: 'priority-high', medium: 'priority-medium', low: 'priority-low', none: 'priority-none' };
     const body = document.getElementById('bodyIssues');
+    if (!allIssues.length) {
+      document.getElementById('loadingIssues').innerHTML = '<div class="empty"><div class="empty-icon">&#x25CB;</div>No work items found</div>';
+      return;
+    }
     body.innerHTML = allIssues.map(i => {
       const sg = i.state_detail?.group || i.state?.group || '';
       return `
@@ -796,12 +949,13 @@ async function loadIssues() {
     document.getElementById('loadingIssues').style.display = 'none';
     document.getElementById('tableIssues').style.display = 'table';
   } catch (e) {
-    document.getElementById('loadingIssues').innerHTML = `<div class="empty"><div class="empty-icon">&#x25CB;</div>${escHtml(e.message)}</div>`;
+    showError('loadingIssues', 'tableIssues', '&#x25CB;', 'Plane', e, 'loadIssues()');
   }
 }
 
 // ═══ Load: Pull Requests ═══
 async function loadPrs() {
+  showLoading('loadingPrs', 'tablePrs', 'Loading pull requests...');
   try {
     const repos = await giteaFetch('/user/repos?sort=updated&limit=20');
     let allPrs = [];
@@ -809,10 +963,15 @@ async function loadPrs() {
       try {
         const prs = await giteaFetch(`/repos/${r.full_name}/pulls?state=open&limit=20`);
         allPrs.push(...prs.map(p => ({ ...p, repo: r.full_name })));
-      } catch {}
+      } catch { /* individual repo failure is non-fatal */ }
     }
     allPrs.sort((a, b) => new Date(b.updated_at) - new Date(a.updated_at));
     const body = document.getElementById('bodyPrs');
+    if (!allPrs.length) {
+      document.getElementById('loadingPrs').innerHTML = '<div class="empty"><div class="empty-icon">&#x21C4;</div>No open pull requests</div>';
+      document.getElementById('countPrs').textContent = '0';
+      return;
+    }
     body.innerHTML = allPrs.map(p => `
       <tr>
         <td style="font-family:var(--mono);font-size:0.85rem;color:var(--accent)">#${p.number}</td>
@@ -830,7 +989,7 @@ async function loadPrs() {
     document.getElementById('loadingPrs').style.display = 'none';
     document.getElementById('tablePrs').style.display = 'table';
   } catch (e) {
-    document.getElementById('loadingPrs').innerHTML = `<div class="empty"><div class="empty-icon">&#x21C4;</div>${escHtml(e.message)}</div>`;
+    showError('loadingPrs', 'tablePrs', '&#x21C4;', 'Gitea', e, 'loadPrs()');
   }
 }
 
@@ -841,6 +1000,7 @@ async function loadActions() {
     document.getElementById('loadingActions').innerHTML = '<div class="empty"><div class="empty-icon">&#x25B6;</div>Configure Woodpecker token in Settings</div>';
     return;
   }
+  showLoading('loadingActions', 'tableActions', 'Loading pipelines...');
   try {
     const repos = await woodpeckerFetch('/user/repos');
     let allPipelines = [];
@@ -848,12 +1008,17 @@ async function loadActions() {
       try {
         const pipelines = await woodpeckerFetch(`/repos/${r.id}/pipelines?per_page=5`);
         allPipelines.push(...(pipelines || []).map(p => ({ ...p, repo_name: r.full_name })));
-      } catch {}
+      } catch { /* individual repo failure is non-fatal */ }
     }
     allPipelines.sort((a, b) => (b.created_at || 0) - (a.created_at || 0));
     const statusIcon = { success: '&#x2714;', failure: '&#x2718;', running: '&#x25CF;', pending: '&#x25CB;', blocked: '&#x25A0;', declined: '&#x2718;', error: '&#x2718;', killed: '&#x2718;' };
     const statusClass = { success: 'success', failure: 'failure', running: 'running', pending: 'pending', error: 'failure', killed: 'failure' };
     const body = document.getElementById('bodyActions');
+    if (!allPipelines.length) {
+      document.getElementById('loadingActions').innerHTML = '<div class="empty"><div class="empty-icon">&#x25B6;</div>No pipelines found</div>';
+      document.getElementById('countActions').textContent = '0';
+      return;
+    }
     body.innerHTML = allPipelines.map(p => `
       <tr>
         <td><span class="status-icon ${statusClass[p.status] || 'pending'}">${statusIcon[p.status] || '?'}</span></td>
@@ -869,7 +1034,7 @@ async function loadActions() {
     document.getElementById('loadingActions').style.display = 'none';
     document.getElementById('tableActions').style.display = 'table';
   } catch (e) {
-    document.getElementById('loadingActions').innerHTML = `<div class="empty"><div class="empty-icon">&#x25B6;</div>${escHtml(e.message)}</div>`;
+    showError('loadingActions', 'tableActions', '&#x25B6;', 'Woodpecker', e, 'loadActions()');
   }
 }
 
@@ -881,19 +1046,21 @@ document.getElementById('searchInput').addEventListener('input', (e) => {
   });
 });
 
-// ═══ Load all ═══
+// ═══ Load all (each panel independent, one failure does not block others) ═══
 async function loadAll() {
   checkHealth();
-  loadCode();
-  loadCommits();
-  loadIssues();
-  loadPrs();
-  loadActions();
+  // Fire all loaders independently so one failure cannot block others
+  loadCode().catch(() => {});
+  loadCommits().catch(() => {});
+  loadIssues().catch(() => {});
+  loadPrs().catch(() => {});
+  loadActions().catch(() => {});
 }
 
 // ═══ Init ═══
 loadAll();
 setInterval(checkHealth, 30000);
+setInterval(loadAll, 120000);
 </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Each dashboard panel now shows a clear "Service unavailable" error with HTTP status details and a retry button when its backing service (Gitea, Plane, Woodpecker) is down, instead of showing blank/broken content
- Health check dots in the top bar now show three states (green=healthy, yellow=degraded, red=down) with hover tooltips displaying response time and last check timestamp
- All API calls have a 10-second timeout, panels load independently so one failure cannot block others, and auto-refresh runs every 2 minutes to recover when services come back

Closes #58

## Test plan
- [ ] Stop Gitea and verify Code/Commits/PRs panels show error state with retry button
- [ ] Stop Plane and verify Issues panel shows error state independently
- [ ] Stop Woodpecker and verify Actions panel shows error state independently
- [ ] Verify health dots turn red for stopped services, green for running
- [ ] Click retry button on an error panel and confirm it attempts to reload
- [ ] Hover over health dots and confirm tooltip shows status and timestamp
- [ ] Start a stopped service and confirm dashboard recovers on next auto-refresh

Generated with [Claude Code](https://claude.com/claude-code)