### PR TITLE
replace netcat listeners with threaded Python HTTP servers (#52)

### DIFF
--- a/bridge/webhook-bridge.sh
+++ b/bridge/webhook-bridge.sh
@@ -210,7 +210,7 @@ process_queue() {
             line=$(flock "${BRIDGE_QUEUE}.lock" bash -c '
                 head -1 "'"$BRIDGE_QUEUE"'"
                 tail -n +2 "'"$BRIDGE_QUEUE"'" > "'"$BRIDGE_QUEUE"'.tmp" && mv "'"$BRIDGE_QUEUE"'.tmp" "'"$BRIDGE_QUEUE"'"
-            ' 2>/dev/null || head -1 "$BRIDGE_QUEUE")
+            ')
             if [[ -n "$line" ]]; then
                 event_type=$(echo "$line" | cut -f1)
                 json_body=$(echo "$line" | cut -f2-)

--- a/bridge/webhook-http.py
+++ b/bridge/webhook-http.py
@@ -85,7 +85,7 @@ class WebhookHandler(BaseHTTPRequestHandler):
             json.loads(body)
             enqueue(event_type, body.decode("utf-8", errors="replace"))
             log(f"Webhook received: {event_type}")
-        except (json.JSONDecodeError, KeyError) as e:
+        except (json.JSONDecodeError, KeyError, AttributeError) as e:
             log(f"WARNING: Failed to parse webhook payload: {e}")
 
     def do_GET(self):

--- a/reviewer/webhook-http.py
+++ b/reviewer/webhook-http.py
@@ -103,7 +103,7 @@ class WebhookHandler(BaseHTTPRequestHandler):
             if repo and sha:
                 enqueue(repo, sha, ref)
                 log(f"Webhook received: {repo} {sha} {ref}")
-        except (json.JSONDecodeError, KeyError) as e:
+        except (json.JSONDecodeError, KeyError, AttributeError) as e:
             log(f"WARNING: Failed to parse webhook payload: {e}")
 
     def do_GET(self):

--- a/reviewer/webhook-server.sh
+++ b/reviewer/webhook-server.sh
@@ -54,7 +54,7 @@ process_queue() {
             line=$(flock "${REVIEW_QUEUE}.lock" bash -c '
                 head -1 "'"$REVIEW_QUEUE"'"
                 tail -n +2 "'"$REVIEW_QUEUE"'" > "'"$REVIEW_QUEUE"'.tmp" && mv "'"$REVIEW_QUEUE"'.tmp" "'"$REVIEW_QUEUE"'"
-            ' 2>/dev/null || head -1 "$REVIEW_QUEUE")
+            ')
             if [[ -n "$line" ]]; then
                 log "Processing: $line"
                 # shellcheck disable=SC2086


### PR DESCRIPTION
## Summary
- Replace single-connection netcat webhook listeners with Python ThreadingHTTPServer
- Both bridge and reviewer can now handle concurrent webhook deliveries
- Queue processing remains sequential in bash (one review at a time)
- HMAC signature verification moved to Python (uses `hmac.compare_digest` for constant-time comparison)
- No new dependencies — uses Python 3 stdlib only

## Test plan
- [x] Pre-commit checks pass
- [ ] Webhook delivery from Gitea is received and processed
- [ ] Multiple simultaneous webhooks don't block each other
- [ ] Signature verification rejects invalid signatures

Fixes #52

🤖 Generated with [Claude Code](https://claude.com/claude-code)